### PR TITLE
migrate from JUL to slf4j

### DIFF
--- a/nimbits_core/pom.xml
+++ b/nimbits_core/pom.xml
@@ -36,7 +36,6 @@
 
     <dependencies>
 
-
         <dependency>
             <groupId>com.nimbits</groupId>
             <artifactId>nimbits_io</artifactId>
@@ -139,6 +138,12 @@
             <scope>provided</scope>
         </dependency>
 
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.6.1</version>
+        </dependency>
+        
 
         <dependency>
             <groupId>org.eclipse.jetty</groupId>

--- a/nimbits_core/src/main/java/com/nimbits/server/api/filter/FilterBase.java
+++ b/nimbits_core/src/main/java/com/nimbits/server/api/filter/FilterBase.java
@@ -32,8 +32,8 @@ import javax.servlet.*;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
-import java.util.logging.Level;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class FilterBase implements Filter {
 
@@ -57,7 +57,7 @@ public class FilterBase implements Filter {
     @Autowired
     private NimbitsCache nimbitsCache;
 
-    private Logger logger = Logger.getLogger(FilterBase.class.getName());
+    private Logger logger = LoggerFactory.getLogger(FilterBase.class.getName());
 
     private User user;
 
@@ -144,7 +144,7 @@ public class FilterBase implements Filter {
             request.setAttribute(Parameters.user.getText(), user);
             return user != null;
         } catch (Throwable ex) {
-            logger.log(Level.SEVERE, ExceptionUtils.getStackTrace(ex), ex);
+            logger.error(ExceptionUtils.getStackTrace(ex), ex);
             return false;
         }
 

--- a/nimbits_core/src/main/java/com/nimbits/server/api/filter/GWTCacheControlFilter.java
+++ b/nimbits_core/src/main/java/com/nimbits/server/api/filter/GWTCacheControlFilter.java
@@ -21,10 +21,11 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.Date;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class GWTCacheControlFilter implements Filter {
-    private final Logger logger = Logger.getLogger(AuthFilter.class.getName());
+    private final Logger logger = LoggerFactory.getLogger(AuthFilter.class.getName());
 
     public void destroy() {
     }

--- a/nimbits_core/src/main/java/com/nimbits/server/api/v3/RestAPI.java
+++ b/nimbits_core/src/main/java/com/nimbits/server/api/v3/RestAPI.java
@@ -61,7 +61,8 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.*;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 @RestController
@@ -84,7 +85,7 @@ public class RestAPI {
     private final EntityDao entityDao;
     private final Gson gson;
 
-    private final Logger logger = Logger.getLogger(RestAPI.class.getName());
+    private final Logger logger = LoggerFactory.getLogger(RestAPI.class.getName());
 
 
 

--- a/nimbits_core/src/main/java/com/nimbits/server/communication/mail/EmailServiceImpl.java
+++ b/nimbits_core/src/main/java/com/nimbits/server/communication/mail/EmailServiceImpl.java
@@ -46,7 +46,8 @@ import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.util.Properties;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Service
 public class EmailServiceImpl implements EmailService {
@@ -61,7 +62,7 @@ public class EmailServiceImpl implements EmailService {
     private ServerInfo serverInfo;
 
 
-    private static final Logger log = Logger.getLogger(EmailServiceImpl.class.getName());
+    private static final Logger log = LoggerFactory.getLogger(EmailServiceImpl.class.getName());
 
     private static final int INT = 128;
     private static final int SECONDS_IN_MINUTE = 60;
@@ -89,7 +90,7 @@ public class EmailServiceImpl implements EmailService {
             }
 
         } catch (MessagingException e) {
-            log.severe(e.getMessage());
+            log.error(e.getMessage());
             e.printStackTrace();
         }
 

--- a/nimbits_core/src/main/java/com/nimbits/server/defrag/Defragmenter.java
+++ b/nimbits_core/src/main/java/com/nimbits/server/defrag/Defragmenter.java
@@ -20,11 +20,12 @@ import com.google.common.collect.ImmutableMap;
 import com.nimbits.client.model.value.Value;
 
 import java.util.*;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 public class Defragmenter {
-    private Logger logger = Logger.getLogger(Defragmenter.class.getName());
+    private Logger logger = LoggerFactory.getLogger(Defragmenter.class.getName());
 
 
     /**
@@ -52,7 +53,7 @@ public class Defragmenter {
 
                 }
             } else {
-                logger.warning("Value Rejected - not healthy");
+                logger.warn("Value Rejected - not healthy");
             }
         }
         int count = 0;

--- a/nimbits_core/src/main/java/com/nimbits/server/orm/validation/RecursionValidation.java
+++ b/nimbits_core/src/main/java/com/nimbits/server/orm/validation/RecursionValidation.java
@@ -29,13 +29,14 @@ import org.apache.commons.lang3.StringUtils;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 public class RecursionValidation {
     private static final int MAX_RECURSION = 10;
     private static final int INT = 1024;
-    private static final Logger log = Logger.getLogger(RecursionValidation.class.getName());
+    private static final Logger log = LoggerFactory.getLogger(RecursionValidation.class.getName());
 
 
     public RecursionValidation( ) {
@@ -107,7 +108,7 @@ public class RecursionValidation {
 
                     count++;
                     if (count > MAX_RECURSION) {
-                        log.warning("trigger failed validation with recursion test");
+                        log.warn("trigger failed validation with recursion test");
                         throw new IllegalArgumentException("The target for this trigger is a trigger for another entity. That's ok, but the" +
                                 "target for that calc is also the trigger for another, and so on for over " + MAX_RECURSION + " steps. We " +
                                 "stopped checking after that, but it looks like this is an infinite loop." + " enabled=" + trigger.isEnabled());

--- a/nimbits_core/src/main/java/com/nimbits/server/process/cron/SystemCron.java
+++ b/nimbits_core/src/main/java/com/nimbits/server/process/cron/SystemCron.java
@@ -49,7 +49,8 @@ import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.util.Date;
 import java.util.List;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -61,7 +62,7 @@ import java.util.logging.Logger;
 
 public class SystemCron extends HttpServlet implements BaseProcessor {
 
-    private static final Logger logger = Logger.getLogger(SystemCron.class.getName());
+    private static final Logger logger = LoggerFactory.getLogger(SystemCron.class.getName());
 
     @Autowired
     private EntityService entityService;

--- a/nimbits_core/src/main/java/com/nimbits/server/process/cron/SystemTaskExecutor.java
+++ b/nimbits_core/src/main/java/com/nimbits/server/process/cron/SystemTaskExecutor.java
@@ -33,10 +33,11 @@ import com.nimbits.server.transaction.user.service.UserService;
 import com.nimbits.server.transaction.value.service.ValueService;
 import org.springframework.core.task.TaskExecutor;
 
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class SystemTaskExecutor {
-    private final Logger logger = Logger.getLogger(SystemTaskExecutor.class.getName());
+    private final Logger logger = LoggerFactory.getLogger(SystemTaskExecutor.class.getName());
 
 
     private final TaskExecutor taskExecutor;
@@ -102,7 +103,7 @@ public class SystemTaskExecutor {
 
 
                 } catch (Exception e) {
-                    logger.severe(e.getMessage());
+                    logger.error(e.getMessage());
                 }
             }
         }

--- a/nimbits_core/src/main/java/com/nimbits/server/process/task/ValueTask.java
+++ b/nimbits_core/src/main/java/com/nimbits/server/process/task/ValueTask.java
@@ -59,11 +59,12 @@ import java.net.URL;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 public class ValueTask extends HttpServlet implements BaseProcessor {
-    private final Logger logger = Logger.getLogger(ValueTask.class.getName());
+    private final Logger logger = LoggerFactory.getLogger(ValueTask.class.getName());
 
     @Autowired
     private EntityService entityService;
@@ -135,7 +136,7 @@ public class ValueTask extends HttpServlet implements BaseProcessor {
             process(geoSpatialDao, taskService, userService, entityDao, valueTask, entityService, blobStore, valueService, summaryService, syncService, subscriptionService,
                     calculationService, dataProcessor, user, point, value);
         } catch (ValueException e) {
-            logger.severe(ExceptionUtils.getStackTrace(e));
+            logger.error(ExceptionUtils.getStackTrace(e));
         }
 
 
@@ -216,12 +217,12 @@ public class ValueTask extends HttpServlet implements BaseProcessor {
                                                 taskService.process(geoSpatialDao, taskService, userService, entityDao, valueTask, entityService, blobStore,
                                                         valueService, summaryService, syncService, subscriptionService, calculationService, dataProcessor, user, pushPoint, lastBroadcast);
                                             } else {
-                                                logger.warning("ignored value since it was the init value: " + lastBroadcast.toString());
+                                                logger.warn("ignored value since it was the init value: " + lastBroadcast.toString());
                                             }
 
                                         }
                                         else {
-                                            logger.warning("other user's broadcast point no longer exists.");
+                                            logger.warn("other user's broadcast point no longer exists.");
                                         }
                                     }
                                 }
@@ -335,7 +336,7 @@ public class ValueTask extends HttpServlet implements BaseProcessor {
 //   value         try {
 //             //   connectedClients.sendLiveEvents(u, point, value, u.getToken());
 //            } catch (IOException e) {
-//                logger.severe(e.getMessage());
+//                logger.error(e.getMessage());
 //            }getMessage
 
             List<SocketStore> socketStores = Collections.emptyList();    //userDao.getSocketSessions(u);
@@ -370,17 +371,17 @@ public class ValueTask extends HttpServlet implements BaseProcessor {
                     if (connection.getResponseCode() == HttpURLConnection.HTTP_OK) {
                         logger.info("post ok");
                     } else {
-                        logger.severe("post to socket relay error " + connection.getResponseCode());
+                        logger.error("post to socket relay error " + connection.getResponseCode());
                     }
                 } catch (Exception e) {
-                    logger.severe(e.getMessage());
+                    logger.error(e.getMessage());
                     e.printStackTrace();
                 }
 
             }
         } catch (Exception ex) {
             ex.printStackTrace();
-            logger.severe(ex.getMessage());
+            logger.error(ex.getMessage());
         }
 
 

--- a/nimbits_core/src/main/java/com/nimbits/server/transaction/calculation/CalculationServiceImpl.java
+++ b/nimbits_core/src/main/java/com/nimbits/server/transaction/calculation/CalculationServiceImpl.java
@@ -41,12 +41,13 @@ import com.nimbits.server.transaction.user.service.UserService;
 import com.nimbits.server.transaction.value.service.ValueService;
 import org.apache.commons.lang3.StringUtils;
 
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 public class CalculationServiceImpl implements CalculationService {
 
-    private static final Logger logger = Logger.getLogger(CalculationService.class.getName());
+    private static final Logger logger = LoggerFactory.getLogger(CalculationService.class.getName());
 
 
     //TODO DI

--- a/nimbits_core/src/main/java/com/nimbits/server/transaction/entity/EntityServiceImpl.java
+++ b/nimbits_core/src/main/java/com/nimbits/server/transaction/entity/EntityServiceImpl.java
@@ -35,7 +35,8 @@ import com.nimbits.server.transaction.value.service.ValueService;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 public class EntityServiceImpl implements EntityService {
@@ -56,7 +57,7 @@ public class EntityServiceImpl implements EntityService {
     private final GeoSpatialDao geoSpatialDao;
 
 
-    final static Logger logger = Logger.getLogger(EntityServiceImpl.class.getName());
+    final static Logger logger = LoggerFactory.getLogger(EntityServiceImpl.class.getName());
 
     public EntityServiceImpl(GeoSpatialDao geoSpatialDao, EmailService emailService, ConnectedClients connectedClients, EntityDao entityDao, BlobStore blobStore) {
 

--- a/nimbits_core/src/main/java/com/nimbits/server/transaction/entity/dao/EntityDaoImpl.java
+++ b/nimbits_core/src/main/java/com/nimbits/server/transaction/entity/dao/EntityDaoImpl.java
@@ -37,13 +37,14 @@ import org.springframework.stereotype.Repository;
 
 import javax.jdo.*;
 import java.util.*;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 @Repository
 public class EntityDaoImpl implements EntityDao {
 
-    private final static Logger logger = Logger.getLogger(EntityDaoImpl.class.getName());
+    private final static Logger logger = LoggerFactory.getLogger(EntityDaoImpl.class.getName());
     private static final int INT = 1024;
 
 
@@ -114,7 +115,7 @@ public class EntityDaoImpl implements EntityDao {
             }
 
         } catch (Exception ex) {
-            logger.severe(ex.getMessage());
+            logger.error(ex.getMessage());
             return Optional.absent();
 
         } finally {
@@ -264,7 +265,7 @@ public class EntityDaoImpl implements EntityDao {
 
         } catch (Exception ex) {
 
-            logger.severe(ex.getMessage());
+            logger.error(ex.getMessage());
             throw ex;
 
         } finally {
@@ -415,7 +416,7 @@ public class EntityDaoImpl implements EntityDao {
                                     }
                                 }
                                 else {
-                                    logger.warning("unexpected null values : " +  GsonFactory.getInstance(true).toJson(c));
+                                    logger.warn("unexpected null values : " +  GsonFactory.getInstance(true).toJson(c));
                                 }
                             }
                             if (!filtered.isEmpty()) {
@@ -457,7 +458,7 @@ public class EntityDaoImpl implements EntityDao {
 
                 }
             }catch (Throwable throwable) {
-                logger.severe(throwable.getMessage());
+                logger.error(throwable.getMessage());
 
             } finally {
                 pm.close();
@@ -635,7 +636,7 @@ public class EntityDaoImpl implements EntityDao {
             return result;
 
         } catch (Exception e) {
-            logger.severe(e.getMessage());
+            logger.error(e.getMessage());
             return Collections.emptyList();
 
         } finally {
@@ -669,7 +670,7 @@ public class EntityDaoImpl implements EntityDao {
             }
 
         } catch (Exception e) {
-            logger.severe(e.getMessage());
+            logger.error(e.getMessage());
             return Optional.absent();
 
         } finally {

--- a/nimbits_core/src/main/java/com/nimbits/server/transaction/subscription/SubscriptionServiceImpl.java
+++ b/nimbits_core/src/main/java/com/nimbits/server/transaction/subscription/SubscriptionServiceImpl.java
@@ -64,12 +64,12 @@ import java.net.URL;
 import java.net.URLEncoder;
 import java.util.Collections;
 import java.util.List;
-import java.util.logging.Level;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 public class SubscriptionServiceImpl implements SubscriptionService {
-    private static final Logger logger = Logger.getLogger(SubscriptionServiceImpl.class.getName());
+    private static final Logger logger = LoggerFactory.getLogger(SubscriptionServiceImpl.class.getName());
 
     public static final String UTF_8 = "UTF-8";
 
@@ -283,7 +283,7 @@ public class SubscriptionServiceImpl implements SubscriptionService {
         try {
             notifyNearbyPoints(geoSpatialDao, taskService, userService, blobStore, entityDao, valueService, calculationService, summaryService, syncService, subscriptionService, dataProcessor , user, point, subscription);
         } catch (IOException e) {
-            logger.log(Level.SEVERE, "error doing proxitmity", e);
+            logger.error("error doing proxitmity", e);
 
         }
 
@@ -336,15 +336,15 @@ public class SubscriptionServiceImpl implements SubscriptionService {
                         //  point.getValue(), user, outgoingFeed);
                         logger.info("sending data to outgoing feed " + outgoingFeed.getName().getValue());
                     } catch (ValueException e) {
-                        logger.severe(e.getMessage());
+                        logger.error(e.getMessage());
                     }
 
                 } else {
-                    logger.severe("attempt to notify a nearby point in a subscription failed because it wasn't found: outgoingFeedName=" + outgoingFeedName);
+                    logger.error("attempt to notify a nearby point in a subscription failed because it wasn't found: outgoingFeedName=" + outgoingFeedName);
                 }
             }
             else {
-                logger.severe("attempt to notify a nearby point in a subscription failed because meta data with outgoing feed is missing");
+                logger.error("attempt to notify a nearby point in a subscription failed because meta data with outgoing feed is missing");
             }
         }
 
@@ -388,13 +388,13 @@ public class SubscriptionServiceImpl implements SubscriptionService {
             if (connection.getResponseCode() == HttpURLConnection.HTTP_OK) {
                 logger.info("sent user to nimbits.com");
             } else {
-                logger.log(Level.SEVERE, "error sending user info to nimbits.com: "
+                logger.error("error sending user info to nimbits.com: "
                         + connection.getResponseCode() + " "
                         + connection.getResponseMessage());
             }
 
         } catch ( Exception e) {
-            logger.log(Level.SEVERE, "error sending user info to nimbits.com", e);
+            logger.error("error sending user info to nimbits.com", e);
         }
     }
 
@@ -477,7 +477,7 @@ public class SubscriptionServiceImpl implements SubscriptionService {
 
             }
         } catch (IOException e) {
-            logger.log(Level.SEVERE, "error with subscription", e);
+            logger.error("error with subscription", e);
         } finally {
             IOUtils.closeQuietly(in);
         }
@@ -542,7 +542,7 @@ public class SubscriptionServiceImpl implements SubscriptionService {
             logger.info(resp);
 
         } catch (Exception e) {
-            logger.severe("Unable to send GCM message." + e.getMessage());
+            logger.error("Unable to send GCM message." + e.getMessage());
 
         }
 
@@ -563,7 +563,7 @@ public class SubscriptionServiceImpl implements SubscriptionService {
             return outbound;
 
         } catch (IOException e) {
-            logger.severe(e.getMessage());
+            logger.error(e.getMessage());
             e.printStackTrace();
         }
         return null;

--- a/nimbits_core/src/main/java/com/nimbits/server/transaction/summary/SummaryServiceImpl.java
+++ b/nimbits_core/src/main/java/com/nimbits/server/transaction/summary/SummaryServiceImpl.java
@@ -43,12 +43,13 @@ import org.springframework.stereotype.Service;
 
 import java.util.Date;
 import java.util.List;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Service
 public class SummaryServiceImpl implements SummaryService {
 
-    private static final Logger logger = Logger.getLogger(SummaryServiceImpl.class.getName());
+    private static final Logger logger = LoggerFactory.getLogger(SummaryServiceImpl.class.getName());
 
 
 

--- a/nimbits_core/src/main/java/com/nimbits/server/transaction/sync/SyncServiceImpl.java
+++ b/nimbits_core/src/main/java/com/nimbits/server/transaction/sync/SyncServiceImpl.java
@@ -38,11 +38,12 @@ import com.nimbits.server.transaction.user.service.UserService;
 import com.nimbits.server.transaction.value.service.ValueService;
 import org.springframework.stereotype.Service;
 
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Service
 public class SyncServiceImpl implements SyncService {
-    protected final static Logger log = Logger.getLogger(SyncServiceImpl.class.getName());
+    protected final static Logger log = LoggerFactory.getLogger(SyncServiceImpl.class.getName());
 
 
 

--- a/nimbits_core/src/main/java/com/nimbits/server/transaction/user/dao/UserDaoImpl.java
+++ b/nimbits_core/src/main/java/com/nimbits/server/transaction/user/dao/UserDaoImpl.java
@@ -36,13 +36,14 @@ import javax.jdo.PersistenceManagerFactory;
 import javax.jdo.Query;
 import javax.jdo.Transaction;
 import java.util.*;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 @Repository
 public class UserDaoImpl implements UserDao {
     private PersistenceManagerFactory persistenceManagerFactory;
-    private final Logger logger = Logger.getLogger(UserDaoImpl.class.getName());
+    private final Logger logger = LoggerFactory.getLogger(UserDaoImpl.class.getName());
 
     public UserDaoImpl() {
         SpringBeanAutowiringSupport.processInjectionBasedOnCurrentContext(this);

--- a/nimbits_core/src/main/java/com/nimbits/server/transaction/user/service/UserServiceImpl.java
+++ b/nimbits_core/src/main/java/com/nimbits/server/transaction/user/service/UserServiceImpl.java
@@ -45,8 +45,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.StringTokenizer;
 import java.util.UUID;
-import java.util.logging.Level;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Service
 public class UserServiceImpl implements UserService {
@@ -54,7 +54,7 @@ public class UserServiceImpl implements UserService {
     public static final String ERROR1 = "Could not authenticate your request.";
 
     public static final int LIMIT = 1000;
-    private Logger logger = Logger.getLogger(UserServiceImpl.class.getName());
+    private Logger logger = LoggerFactory.getLogger(UserServiceImpl.class.getName());
 
 
     private final UserDao userDao;

--- a/nimbits_core/src/main/java/com/nimbits/server/transaction/user/service/UserServiceRpcImpl.java
+++ b/nimbits_core/src/main/java/com/nimbits/server/transaction/user/service/UserServiceRpcImpl.java
@@ -44,13 +44,14 @@ import javax.servlet.ServletException;
 import java.util.Date;
 import java.util.List;
 import java.util.UUID;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Service
 public class UserServiceRpcImpl extends RemoteServiceServlet implements UserServiceRpc {
 
     private static final String ANON_NIMBITS_COM = "anon@nimbits.com";
-    private static final Logger log = Logger.getLogger(UserServiceRpcImpl.class.getName());
+    private static final Logger log = LoggerFactory.getLogger(UserServiceRpcImpl.class.getName());
 
     @Autowired
     private EntityService entityService;

--- a/nimbits_core/src/main/java/com/nimbits/server/transaction/value/service/ValueServiceImpl.java
+++ b/nimbits_core/src/main/java/com/nimbits/server/transaction/value/service/ValueServiceImpl.java
@@ -44,13 +44,14 @@ import com.nimbits.server.transaction.sync.SyncService;
 import com.nimbits.server.transaction.user.service.UserService;
 
 import java.util.*;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static java.lang.Math.abs;
 
 public class ValueServiceImpl implements ValueService {
 
-    private static final Logger logger = Logger.getLogger(ValueServiceImpl.class.getName());
+    private static final Logger logger = LoggerFactory.getLogger(ValueServiceImpl.class.getName());
 
     private ChartHelper chartHelper;
 

--- a/nimbits_core/src/main/java/com/nimbits/server/transaction/value/service/ValueServiceRpcImpl.java
+++ b/nimbits_core/src/main/java/com/nimbits/server/transaction/value/service/ValueServiceRpcImpl.java
@@ -46,12 +46,13 @@ import org.springframework.web.context.support.SpringBeanAutowiringSupport;
 
 import javax.servlet.ServletException;
 import java.util.*;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Service
 public class ValueServiceRpcImpl extends RemoteServiceServlet implements ValueServiceRpc {
 
-    private final static Logger logger = Logger.getLogger(ValueServiceRpcImpl.class.getName());
+    private final static Logger logger = LoggerFactory.getLogger(ValueServiceRpcImpl.class.getName());
     @Autowired
     private TaskService taskService;
 

--- a/nimbits_gae/pom.xml
+++ b/nimbits_gae/pom.xml
@@ -49,6 +49,12 @@
             <!--<version>1.7.12</version>-->
         <!--</dependency>-->
 
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.6.1</version>
+        </dependency>
+
 
         <dependency>
             <groupId>com.nimbits</groupId>

--- a/nimbits_gae/src/main/java/com/nimbits/server/ApplicationListener.java
+++ b/nimbits_gae/src/main/java/com/nimbits/server/ApplicationListener.java
@@ -19,12 +19,13 @@ package com.nimbits.server;
 
 import javax.servlet.ServletContextEvent;
 import javax.servlet.ServletContextListener;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 public class ApplicationListener implements ServletContextListener {
 
-    private static final Logger log = Logger.getLogger(ApplicationListener.class.getName());
+    private static final Logger log = LoggerFactory.getLogger(ApplicationListener.class.getName());
 
     @Override
     public void contextInitialized(ServletContextEvent servletContextEvent) {

--- a/nimbits_gae/src/main/java/com/nimbits/server/auth/AuthServiceImpl.java
+++ b/nimbits_gae/src/main/java/com/nimbits/server/auth/AuthServiceImpl.java
@@ -38,7 +38,8 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 public class AuthServiceImpl implements AuthService {

--- a/nimbits_gae/src/main/java/com/nimbits/server/geo/GeoSpatialDaoImpl.java
+++ b/nimbits_gae/src/main/java/com/nimbits/server/geo/GeoSpatialDaoImpl.java
@@ -27,7 +27,8 @@ import com.nimbits.client.model.user.User;
 import com.nimbits.server.transaction.entity.dao.EntityDao;
 
 import java.util.*;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class GeoSpatialDaoImpl implements GeoSpatialDao {
 //    public static final String UUID = "uuid";
@@ -40,7 +41,7 @@ public class GeoSpatialDaoImpl implements GeoSpatialDao {
 
     private final DatastoreService datastore = DatastoreServiceFactory.getDatastoreService();
 
-    private static final Logger logger = Logger.getLogger(GeoSpatialDao.class.getName());
+    private static final Logger logger = LoggerFactory.getLogger(GeoSpatialDao.class.getName());
 
     public GeoSpatialDaoImpl(EntityDao entityDao) {
         this.entityDao = entityDao;
@@ -64,7 +65,7 @@ public class GeoSpatialDaoImpl implements GeoSpatialDao {
                 points.add((Point) p.get());
             }
             else {
-                logger.warning("deleting a file since point wasn't found: " + id);
+                logger.warn("deleting a file since point wasn't found: " + id);
                 index.delete(id);
             }
         }

--- a/nimbits_gae/src/main/java/com/nimbits/server/process/BlobStoreImpl.java
+++ b/nimbits_gae/src/main/java/com/nimbits/server/process/BlobStoreImpl.java
@@ -42,7 +42,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 public class BlobStoreImpl implements BlobStore {
@@ -58,7 +59,7 @@ public class BlobStoreImpl implements BlobStore {
 
     public static final String SNAPSHOT = "SNAPSHOT";
     public static final int INITIAL_CAPACITY = 100;
-    private final Logger logger = Logger.getLogger(BlobStoreImpl.class.getName());
+    private final Logger logger = LoggerFactory.getLogger(BlobStoreImpl.class.getName());
 
 
     private final Gson gson =  GsonFactory.getInstance(true);
@@ -87,7 +88,7 @@ public class BlobStoreImpl implements BlobStore {
                 valueService.storeValues(blobStore, entity, retObj);
             }
         } catch (IOException ex) {
-            logger.severe(ExceptionUtils.getStackTrace(ex));
+            logger.error(ExceptionUtils.getStackTrace(ex));
         }
     }
 
@@ -244,14 +245,14 @@ public class BlobStoreImpl implements BlobStore {
             segment = stringBuilder.toString();
         } catch (Exception e) {
 
-            logger.severe(e.getMessage());
+            logger.error(e.getMessage());
 
         } finally {
             if (reader != null) {
                 try {
                     reader.close();
                 } catch (IOException e) {
-                    logger.severe(e.getMessage());
+                    logger.error(e.getMessage());
                 }
             }
         }
@@ -330,7 +331,7 @@ public class BlobStoreImpl implements BlobStore {
 
             writeChannel.close();
         } catch (Exception e) {
-            logger.severe(e.getMessage());
+            logger.error(e.getMessage());
         }
     }
 

--- a/nimbits_gae/src/main/java/com/nimbits/server/process/cron/UsageResetCron.java
+++ b/nimbits_gae/src/main/java/com/nimbits/server/process/cron/UsageResetCron.java
@@ -125,7 +125,7 @@ public class UsageResetCron extends HttpServlet {
 ////                               // valueService.recordValue(adminUser, (Point) entity, zero, true);
 ////                            } catch (ValueException e) {
 ////                                resp.sendError(HttpServletResponse.SC_INTERNAL_SERVER_ERROR);
-////                                logger.severe(e.getMessage());
+////                                logger.error(e.getMessage());
 ////                            }
 //                        }
 //                    }

--- a/nimbits_gae/src/main/java/com/nimbits/server/transaction/cache/NimbitsCacheImpl.java
+++ b/nimbits_gae/src/main/java/com/nimbits/server/transaction/cache/NimbitsCacheImpl.java
@@ -23,11 +23,12 @@ import net.sf.jsr107cache.CacheFactory;
 import net.sf.jsr107cache.CacheManager;
 
 import java.util.Collections;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 public class NimbitsCacheImpl extends BaseCache implements NimbitsCache {
-    final static Logger logger = Logger.getLogger(NimbitsCacheImpl.class.getName());
+    final static Logger logger = LoggerFactory.getLogger(NimbitsCacheImpl.class.getName());
 
     private Cache cache;
 

--- a/nimbits_io/pom.xml
+++ b/nimbits_io/pom.xml
@@ -66,6 +66,12 @@
     <dependencies>
 
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.6.1</version>
+        </dependency>
+
+        <dependency>
             <groupId>com.squareup.retrofit</groupId>
             <artifactId>retrofit</artifactId>
             <version>1.7.0</version>

--- a/nimbits_io/src/main/java/com/nimbits/client/io/command/ListCommand.java
+++ b/nimbits_io/src/main/java/com/nimbits/client/io/command/ListCommand.java
@@ -21,12 +21,13 @@ import com.nimbits.client.model.instance.Instance;
 import com.nimbits.client.model.user.User;
 
 import java.util.List;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class ListCommand extends AbstractCommand implements Command {
 
     private final static String USAGE = "list child entities";
-    private final static Logger logger = Logger.getLogger(ListCommand.class.getName());
+    private final static Logger logger = LoggerFactory.getLogger(ListCommand.class.getName());
 
     public ListCommand(User user, Entity current, Instance server, List<Entity> tree) {
         super(user, current, server, tree);

--- a/nimbits_server/pom.xml
+++ b/nimbits_server/pom.xml
@@ -46,6 +46,12 @@
     <dependencies>
 
         <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>1.6.1</version>
+        </dependency>
+
+        <dependency>
             <groupId>com.nimbits</groupId>
             <artifactId>nimbits_core</artifactId>
             <version>3.9.61-SNAPSHOT</version>

--- a/nimbits_server/src/main/java/com/nimbits/server/ApplicationListener.java
+++ b/nimbits_server/src/main/java/com/nimbits/server/ApplicationListener.java
@@ -22,12 +22,13 @@ import java.sql.Driver;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.util.Enumeration;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 public class ApplicationListener implements ServletContextListener {
 
-    private static final Logger log = Logger.getLogger(ApplicationListener.class.getName());
+    private static final Logger log = LoggerFactory.getLogger(ApplicationListener.class.getName());
 
 
 

--- a/nimbits_server/src/main/java/com/nimbits/server/process/BlobStoreImpl.java
+++ b/nimbits_server/src/main/java/com/nimbits/server/process/BlobStoreImpl.java
@@ -39,14 +39,15 @@ import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Type;
 import java.util.*;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 public class BlobStoreImpl implements BlobStore {
 
     public static final String SNAPSHOT = "SNAPSHOT";
     public static final int INITIAL_CAPACITY = 10000;
-    private final Logger logger = Logger.getLogger(BlobStoreImpl.class.getName());
+    private final Logger logger = LoggerFactory.getLogger(BlobStoreImpl.class.getName());
     private final Gson gson =  GsonFactory.getInstance(true);
 
 
@@ -248,7 +249,7 @@ public class BlobStoreImpl implements BlobStore {
             }
             return ImmutableList.copyOf(models);
         } catch (Exception e) {
-            logger.severe(e.getMessage());
+            logger.error(e.getMessage());
 
             return Collections.emptyList();
 

--- a/nimbits_server/src/main/java/com/nimbits/server/process/task/TaskServiceImpl.java
+++ b/nimbits_server/src/main/java/com/nimbits/server/process/task/TaskServiceImpl.java
@@ -32,12 +32,12 @@ import com.nimbits.server.transaction.sync.SyncService;
 import com.nimbits.server.transaction.user.service.UserService;
 import com.nimbits.server.transaction.value.service.ValueService;
 
-import java.util.logging.Level;
-import java.util.logging.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class TaskServiceImpl implements TaskService {
 
-    Logger logger = Logger.getLogger(TaskService.class.getName());
+    Logger logger = LoggerFactory.getLogger(TaskService.class.getName());
 
     public TaskServiceImpl() {
 
@@ -69,7 +69,7 @@ public class TaskServiceImpl implements TaskService {
                     dataProcessor, user, point, value);
         } catch (Exception e) {
 
-            logger.log(Level.SEVERE,"Error running value task", e);
+            logger.error("Error running value task", e);
         }
 
 


### PR DESCRIPTION
slf4j migrator is used for migrating
http://www.slf4j.org/migrator.html

nimbits_core\src\main\java\com\nimbits\client\ui has been untouched, since it will be compiled to JS by gwt, which uses JUL for console logs.

now it is easy to use JUL, log4j or logback for logging, just put appropriate jars into classpath.